### PR TITLE
updatedindex.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
   <link rel="stylesheet" href="/static/css/style.css">
   <link rel="stylesheet" href="/static/css/clouds.css">
 
-  <meta name="description" content="A bypass for Google's SH1MMER mitigations, allowing you to downgrade and bypass enterprise enrollment on Chromebooks which have recieved the patch, created by Mercury Workshop">
+  <meta name="description" content="A bypass for Google's SH1MMER mitigations, allowing you to downgrade and bypass enterprise enrollment on Chromebooks which have received the patch, created by Mercury Workshop">
   <meta name="author" content="Mercury Workshop">
   <meta name="keywords" content="E-Halcyon, Halcyon, RecoMod, SH1MMER, ChromeOS, Chrome OS, Chromebook, unenrollment, bypassing, exploit, unblocker">
   <meta name="darkreader-lock">
   <meta property="og:title" content="E-Halcyon">
   <meta property="og:url" content="https://fog.gay">
-  <meta property="og:description" content="A bypass for Google's SH1MMER mitigations, allowing you to downgrade and bypass enterprise enrollment on Chromebooks which have recieved the patch.">
+  <meta property="og:description" content="A bypass for Google's SH1MMER mitigations, allowing you to downgrade and bypass enterprise enrollment on Chromebooks which have received the patch.">
   <meta property="og:image" content="https://fog.gay/static/img/mercury.png">
   <meta property="og:type" content="website">
 
@@ -48,7 +48,7 @@
   <div id="content">
     <div id="content_title" class="description">
       <h1>Defog Your Chromebook</h1>
-      <p>E-Halcyon is a bypass for "The Fog," which is Google's mitigation for the unenrollment and downgrading of Chrome OS devices. It allows you to downgrade and bypass enterprise enrollment on Chromebooks, even if it's received the update that patched downgrading and enrollment escape.</p>
+      <p>E-Halcyon is an exploit to bypass "The Fog", which is Google's mitigation for the unenrollment and downgrading of Chrome OS devices. It allows you to downgrade and bypass enterprise enrollment on Chromebooks, even if it has received the update that patches downgrading and enrollment escape.</p>
       <p>E-Halcyon is developed by Mercury Workshop, the same developers behind SH1MMER.</p>
       <a href="#instructions" id="mainbutton">
         <!-- todo: fix this mess of a button-->
@@ -60,24 +60,26 @@
       <script>document.getElementById("spacer").style.height = "170vh"</script>
     </div>
 
-    <div class="description" id="instructions">
+    <div class="description" id="instructions">  
       <h1>Instructions:</h1>
 
       <!-- note: please just enable word wrap on your editor instead of screwing up the indentation for everyone else -->
       <!-- coolelectronics, you better disable your auto-formatter -->
-      <p>First of all, you'll need a linux PC or VM. WSL is not guaranteed to work</p>
-      <p>Now, you'll need to boot into <a href="https://sh1mmer.me">SH1MMER</a>, and press the Un-Enroll option. It won't truly unenroll you if you've received the 112 update patching unenrollment and downgrading, but it is still a necessary step for the rest of this. If you've never used SH1MMER before or don't have an image lying around, make sure to follow all the instructions on <a href="https://sh1mmer.me">sh1mmer.me</a> for unenrollment before proceeding with the rest of the tutorial here</p>
-      <p>Next, you need a version 107 recovery image corresponding to your board, which you can pick up from <a href="https://chrome100.dev">chrome100.dev</a>. Once you've downloaded the right image for your board and have confirmed it's for version 107, unzip it and save it to a safe place. Now open up a terminal and type in the following commands (make sure to replace /path/to/recovery/image.bin with the actual path)</p>
-
+      <p>To build the modified recovery image yourself, you'll need a Linux PC or VM (Virtual Machine). WSL (Windows Subsystem for Linux) is not guaranteed to work. If you want a prebuilt modified recovery image, you can find one corresponding to your board at <a href="https://dl.osu.bio/">dl.osu.bio</a>, download it, and directly boot it after flashing it to a USB Drive.</p>
+      <p>Now, you'll need to boot into <a href="https://sh1mmer.me">SH1MMER</a> on your Chromebook, and press the Un-Enroll option. It won't truly unenroll you if you've received the 112 update patching unenrollment and downgrading, but it still is a necessary step for the rest of the procedure. If you've never used SH1MMER before or don't have an image lying around, make sure to follow all the instructions on <a href="https://sh1mmer.me">sh1mmer.me</a> before proceeding with the rest of the tutorial here.</p>
+      <p>Next, if you're building the recovery image, you need a version 107 recovery image corresponding to your board, which you can pick up from <a href="https://chrome100.dev">chrome100.dev</a>. Once you've downloaded the right image for your board and have confirmed it's for version 107, unzip it and save it to a safe place. Now, open up a terminal and type in the following commands:</p>
+      
       <!--have to do this or else you get weird indentation on the rendered page-->
       <pre>git clone https://github.com/MercuryWorkshop/RecoMod
 cd RecoMod
 chmod +x recomod.sh
 sudo ./recomod.sh -i /path/to/recovery/image.bin --halcyon --rw_legacy</pre>
 
-      <p>The script will modify the image in place, and it can now be flashed with a standard recovery tool onto a USB of your choice.</p>
-      <p>Enable developer mode and get to the dev mode block screen similarly to how you would with SH1MMER, then plug in the USB. The recovery screen will show up, and at this point you need to start spamming the E key on your keyboard. It will begin a 5 minute wait sequence, and near the end of the 5 minutes start spamming E again. You will only have to wait 5 minutes once, subsequent boots will have the 5 minute wait omitted</p>
-      <p>The boot splash will show, and you will enter a special menu. Use arrow keys to navigate the cursor down to "activate halcyon environment" and press enter. Then navigate down to "Install halcyon semi-tethered" and wait for it to finish. Once it's finished, go back to "activate halcyon environment" and press "Boot halcyon semi-tethered". and you will be booted into a downgraded and unenrolled ChromeOS environment.</p>
+      <p>[Ensure that you substitute <i>/path/to/recovery/image.bin</i> with the precise file path; as in indicating the location of your recovery image within your files application.]</p>
+      <p>The script will modify the image in place, and it can now be flashed with a standard recovery tool onto a USB drive of your choice.</p>
+      <p>Exit SH1MMER and press <i>"Power (⏻) + Reload (↻) + ESC"</i> to get back to the recovery screen. Make sure developer mode is enabled, then plug in the USB. Once the recovery screen shows up, you need to start spamming the E key on your keyboard. It will begin a 5 minute wait sequence, and near the end of the 5 minutes start spamming E again. You will only have to wait 5 minutes once, subsequent boots will have the 5 minute wait omitted.</p>
+      <p>The boot splash will show, and you will enter a special menu. First, navigate to "Reset System" using the arrow keys, press enter, and consent to reset your device. Next, it will show the types of reset methods. Navigate to "Pressurewash" and click enter. It should finish in a few moments.</p>
+      <p>Lastly, Use the arrow keys to navigate the cursor to "Activate Halcyon Environment" and press enter. Then navigate to "Install Halcyon Semi-Tethered", press enter, and wait for it to install. Once done, navigate to "Activate Halcyon Environment" again, and click "Boot Halcyon Semi-Tethered". You should now be booted into a downgraded and unenrolled ChromeOS environment with developer mode enabled.</p>
     </div>
 
     <div style="height:10vh">
@@ -88,43 +90,48 @@ sudo ./recomod.sh -i /path/to/recovery/image.bin --halcyon --rw_legacy</pre>
         <!-- using h2 here for some actual hierarchy and no ugly css -->
         <li>
           <h2>How does this work?</h2>
-          <p>See the <a href="https://coolelectronics.me/blog/breaking-cros-5">writeup</a> for more information</p>
+          <p>See the <a href="https://coolelectronics.me/blog/breaking-cros-5">writeup</a> for more information.</p>
         </li>
         <li>
           <h2>Can the admins see that I'm doing this?</h2>
           <p>No.</p>
         </li>
         <li>
-          <h2>Why don't my history/cookies/etc save after a reboot?</h2>
-          <p>Unfixable restriction of cryptohome. See the <a href="https://coolelectronics.me/blog/breaking-cros-5">writeup</a> for more information</p>
+          <h2>Why doesn't my Chromebook's local data in Halcyon save after a reboot?</h2>
+          <p>Unfixable restriction of cryptohome. See the <a href="https://coolelectronics.me/blog/breaking-cros-5">writeup</a> for more information.</p>
         </li>
         <li>
-          <h2>Why is my Chromebook "Missing or damaged?"</h2>
-          <p>After installing E-Halcyon, you won't be able to boot Chrome OS normally. You'll have to keep the usb around to jumpstart the booting process</p>
+          <h2>Why does my Chromebook screen show "Missing or damaged", or "Confirm returning to secure mode" when I power off/reboot in Halcyon?</h2>
+          <p>After installing E-Halcyon, you won't be able to boot Chrome OS normally. You'll have to keep the USB drive around to jumpstart the booting process.</p>
         </li>
         <li>
           <h2>Where do I report bugs?</h2>
-          <p>The RecoMod <a href="//github.com/MercuryWorkshop/RecoMod">GitHub</a></p>
+          <p>The RecoMod <a href="//github.com/MercuryWorkshop/RecoMod">GitHub</a>.</p>
         </li>
         <li>
-          <h2>Why does it say "E mode not activated" when I try to boot halcyon?</h2>
-          <p>You spammed the E key when starting at the wrong time, or not at all</p>
+          <h2>Why does it say "E mode not activated" when I try to boot Halcyon in the RecoMod menu?</h2>
+          <p>You spammed the E key when starting at the wrong time, or not at all.</p>
+        </li>
+        <li>
+          <h2>Why does booting Halcyon still show enterprise enrollment?</h2>
+          <p>You forgot to click "Pressurewash" on the RecoMod menu before installing and booting Halcyon.</p>
         </li>
       </ul>
     </div>
     <div id="credits" class="description">
-      <h1>Credits:</h1>
+      <h1>Credits:</h1>  
       <ul style="width: 100%">
         <li>CoolElectronics - RecoMod, working switch_root, and everything else</li>
         <li>OlyB - Insight and contributions to the RecoMod script</li>
         <li>vk6 - Created this website</li>
+        <li>UnableOven2035 - Edited this website</li>
       </ul>
     </div>
     <div id="footer">
       <img src="/static/img/mercury.png" width="48px" height="48px" alt="The Mercury Workshop logo">
       <div style="flex-grow: 1">
-        <p><b>E-Halcyon / RecoMod</b></p>
-        <a id="copyright_text" href="https://mercurywork.shop">Copyright (c) 2023 Mercury Workshop</a><br>
+        <p><b>E-Halcyon | RecoMod</b></p>
+        <a id="copyright_text" href="https://mercurywork.shop">Copyright &copy; 2024 Mercury Workshop</a><br>
       </div>
 
       <div id="fedi_plug"><a href="https://akkoma.mercurywork.shop">fediverse server</a></div>


### PR DESCRIPTION
/1) Lines 13 and 19: Changed "recieved" to "received" due to spelling error.
2) Line 68: Replaced "First of all, you'll need" with "To build the modified recovery image yourself, you'll need".
3) Line 68: Replaced "linux" with "Linux".
4) Line 68: Added brackets containing the respective full forms of both VM and WSL after their short forms.
5) Line 68: Added a full stop to the end of the second sentence.
6) Line 68: Added " If you want a prebuilt modified recovery image, you can find one corresponding to your board at <a href="https://dl.osu.bio/">dl.osu.bio</a>, download it, and directly boot it after flashing it to a USB drive.".
7) Line 69: Replaced "it is still a necessary step for the rest of this" with "it still is a necessary step for the rest of the procedure".
8) Line 69: Removed "for unenrollment".
9) Line 69: Added a full stop to the third sentence.
10) Line 70: Replaced "Next, " with "Next, if you're building the recovery image,".
11) Line 70: Replaced "Now open up a terminal" with "Now, open up a terminal".
12) Line 70: Removed "(make sure to replace /path/to/recovery/image.bin with the actual path)".
13) Line 70: Added ":" after "type in the following commands".
14) Line 69: Replaced "you'll need to boot into <a href="https://sh1mmer.me">SH1MMER</a>, and press the Un-Enroll option" with "you'll need to boot into <a href="https://sh1mmer.me">SH1MMER</a> on your Chromebook, and press the Un-Enroll option".
15) Line 79: Replaced "Enable developer mode and get to the dev mode block screen similarly to how you would with SH1MMER, then plug in the USB" with "Exit SH1MMER and press <i>"Power (⏻) + Reload (↻) + ESC"</i> to get back to the recovery screen. Make sure developer mode is enabled, then plug in the USB".
16) Line 79: Added "drive" to "USB".
17) Line 51: Replaced "E-Halcyon is a bypass for "The Fog," which is Google's mitigation for the unenrollment and downgrading of Chrome OS devices. It allows you to downgrade and bypass enterprise enrollment on Chromebooks, even if it's received the update that patched downgrading and enrollment escape." with "E-Halcyon is an exploit to bypass "The Fog", which is Google's mitigation for the unenrollment and downgrading of Chrome OS devices. It allows you to downgrade and bypass enterprise enrollment on Chromebooks, even if it has received the update that patches downgrading and enrollment escape.".
18) Line 78: Added <p tag: "<p[Ensure that you substitute <i/path/to/recovery/image.bin</i with the precise file path; as in indicating the location of your recovery image within your files application.]</p".
19) Line 134: Replaced "Copyright (c) 2023 Mercury Workshop" with "Copyright &copy; 2024 Mercury Workshop".
20) Line 133: Replaced "/" with "|".    
21) Line 80: Replaced "The recovery screen will show up, and at this point" with "Once the recovery screen shows up,".
22) Line 80: Added a full stop to the end of the line.
23) Line 81: Replaced "The boot splash will show, and you will enter a special menu. Use arrow keys to navigate the cursor down to "activate halcyon environment" and press enter. Then navigate down to "Install halcyon semi-tethered" and wait for it to finish. Once it's finished, go back to "activate halcyon environment" and press "Boot halcyon semi-tethered". and you will be booted into a downgraded and unenrolled ChromeOS environment." with "The boot splash will show, and you will enter a special menu. First, navigate to "Reset System" using the arrow keys, press enter, and consent to reset your device. Next, it will show the types of reset methods. Navigate to "Pressurewash" and click enter. It should finish in a few moments.".
24) Line 82: Added <p tag: "<pLastly, Use the arrow keys to navigate the cursor to "Activate Halcyon Environment" and press enter. Then navigate to "Install Halcyon Semi-Tethered", press enter, and wait for it to install. Once done, navigate to "Activate Halcyon Environment" again, and click "Boot Halcyon Semi-Tethered". You should now be booted into a downgraded and unenrolled ChromeOS environment with developer mode enabled.</p".
25) Line 93: Added full stop to the end of the sentence.
26) Line 100: Replaced "Why don't my history/cookies/etc save after a reboot?" with "Why doesn't my Chromebook's local data in Halcyon save after a reboot?".
27) Line 101: Added a full stop to the end of the second sentence.
28) Line 104: Replaced "Why is my Chromebook "Missing or damaged? with "Why does my Chromebook screen show "Missing or damaged", or "Confirm returning to secure mode" when I power off/reboot in Halcyon?".
29) Line 105: Replaced "usb" with "USB drive".
30) Line 105: Added a full stop to the end of the second sentence.
31) Line 109: Added a full stop to the end of the sentence.
32) Line 112: Replaced "Why does it say "E mode not activated" when I try to boot halcyon?" with "Why does it say "E mode not activated" when I try to boot Halcyon in the RecoMod menu?".
33) Line 113: Added a full stop to the end of the sentence.
34) Line 127: Added <li tag: "<liUnableOven2035 - Edited this website</li".
35) Line 115: Added <li tag: " <li<h2Why does booting Halcyon still show Enterprise Enrollment?</h2<pYou forgot to click "Pressurewash" on the RecoMod menu before installing and booting Halcyon.</p</li".



[sorry for bad comment layout, the code is somehow being registered in the comment so its super weird]
